### PR TITLE
Improving exception propagation for debugging

### DIFF
--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -9,7 +9,7 @@ from .transaction import (Transaction, TransactionError,
                           TransactionOperationError, TransactionState)
 
 __name__ = "restio"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     'BaseModel',

--- a/restio/transaction.py
+++ b/restio/transaction.py
@@ -29,7 +29,7 @@ class TransactionError(Exception):
     Represents a collection of exceptions raised during the `commit` of a Transaction.
     """
     def __init__(self, errors: Deque[TransactionOperationError], processed_models: Deque[BaseModel]):
-        super().__init__()
+        super().__init__(errors)
         self.errors = errors
         self.models = processed_models
 


### PR DESCRIPTION
This change propagates the list of errors happening within a transaction back to the parent class Exception of TransactionError. This improves debugging in downstream projects when errors are raised from DAOs.

Resolves #11 