### PR TITLE
Improved error handling with DAOTask

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,13 +34,6 @@
             ],
             "version": "==1.5"
         },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -50,17 +43,17 @@
         },
         "babel": {
             "hashes": [
-                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
-                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
+                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
+                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
-            "version": "==2.7.0"
+            "version": "==2.8.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -71,41 +64,40 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6",
-                "sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650",
-                "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5",
-                "sha256:19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d",
-                "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351",
-                "sha256:245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755",
-                "sha256:331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef",
-                "sha256:386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca",
-                "sha256:3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca",
-                "sha256:60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9",
-                "sha256:63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc",
-                "sha256:6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5",
-                "sha256:6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f",
-                "sha256:7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe",
-                "sha256:826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888",
-                "sha256:93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5",
-                "sha256:9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce",
-                "sha256:af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5",
-                "sha256:bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e",
-                "sha256:bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e",
-                "sha256:c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9",
-                "sha256:dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437",
-                "sha256:df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1",
-                "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c",
-                "sha256:e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24",
-                "sha256:e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47",
-                "sha256:eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2",
-                "sha256:eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28",
-                "sha256:ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c",
-                "sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7",
-                "sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0",
-                "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
+                "sha256:0101888bd1592a20ccadae081ba10e8b204d20235d18d05c6f7d5e904a38fc10",
+                "sha256:04b961862334687549eb91cd5178a6fbe977ad365bddc7c60f2227f2f9880cf4",
+                "sha256:1ca43dbd739c0fc30b0a3637a003a0d2c7edc1dd618359d58cc1e211742f8bd1",
+                "sha256:1cbb88b34187bdb841f2599770b7e6ff8e259dc3bb64fc7893acf44998acf5f8",
+                "sha256:232f0b52a5b978288f0bbc282a6c03fe48cd19a04202df44309919c142b3bb9c",
+                "sha256:24bcfa86fd9ce86b73a8368383c39d919c497a06eebb888b6f0c12f13e920b1a",
+                "sha256:25b8f60b5c7da71e64c18888f3067d5b6f1334b9681876b2fb41eea26de881ae",
+                "sha256:2714160a63da18aed9340c70ed514973971ee7e665e6b336917ff4cca81a25b1",
+                "sha256:2ca2cd5264e84b2cafc73f0045437f70c6378c0d7dbcddc9ee3fe192c1e29e5d",
+                "sha256:2cc707fc9aad2592fc686d63ef72dc0031fc98b6fb921d2f5395d9ab84fbc3ef",
+                "sha256:348630edea485f4228233c2f310a598abf8afa5f8c716c02a9698089687b6085",
+                "sha256:40fbfd6b044c9db13aeec1daf5887d322c710d811f944011757526ef6e323fd9",
+                "sha256:46c9c6a1d1190c0b75ec7c0f339088309952b82ae8d67a79ff1319eb4e749b96",
+                "sha256:591506e088901bdc25620c37aec885e82cc896528f28c57e113751e3471fc314",
+                "sha256:5ac71bba1e07eab403b082c4428f868c1c9e26a21041436b4905c4c3d4e49b08",
+                "sha256:5f622f19abda4e934938e24f1d67599249abc201844933a6f01aaa8663094489",
+                "sha256:65bead1ac8c8930cf92a1ccaedcce19a57298547d5d1db5c9d4d068a0675c38b",
+                "sha256:7362a7f829feda10c7265b553455de596b83d1623b3d436b6d3c51c688c57bf6",
+                "sha256:7f2675750c50151f806070ec11258edf4c328340916c53bac0adbc465abd6b1e",
+                "sha256:960d7f42277391e8b1c0b0ae427a214e1b31a1278de6b73f8807b20c2e913bba",
+                "sha256:a50b0888d8a021a3342d36a6086501e30de7d840ab68fca44913e97d14487dc1",
+                "sha256:b7dbc5e8c39ea3ad3db22715f1b5401cd698a621218680c6daf42c2f9d36e205",
+                "sha256:bb3d29df5d07d5399d58a394d0ef50adf303ab4fbf66dfd25b9ef258effcb692",
+                "sha256:c0fff2733f7c2950f58a4fd09b5db257b00c6fec57bf3f68c5bae004d804b407",
+                "sha256:c792d3707a86c01c02607ae74364854220fb3e82735f631cd0a345dea6b4cee5",
+                "sha256:c90bda74e16bcd03861b09b1d37c0a4158feda5d5a036bb2d6e58de6ff65793e",
+                "sha256:cfce79ce41cc1a1dc7fc85bb41eeeb32d34a4cf39a645c717c0550287e30ff06",
+                "sha256:eeafb646f374988c22c8e6da5ab9fb81367ecfe81c70c292623373d2a021b1a1",
+                "sha256:f425f50a6dd807cb9043d15a4fcfba3b5874a54d9587ccbb748899f70dc18c47",
+                "sha256:fcd4459fe35a400b8f416bc57906862693c9f88b66dc925e7f2a933e77f6b18b",
+                "sha256:ff3936dd5feaefb4f91c8c1f50a06c588b5dc69fba4f7d9c79a6617ad80bb7df"
             ],
             "index": "pypi",
-            "version": "==4.5.4"
+            "version": "==5.0.1"
         },
         "doc8": {
             "hashes": [
@@ -154,10 +146,10 @@
         },
         "imagesize": {
             "hashes": [
-                "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
-                "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
+                "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
+                "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
-            "version": "==1.1.0"
+            "version": "==1.2.0"
         },
         "jinja2": {
             "hashes": [
@@ -222,30 +214,30 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
-                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
             ],
-            "version": "==7.2.0"
+            "version": "==8.0.2"
         },
         "mypy": {
             "hashes": [
-                "sha256:1521c186a3d200c399bd5573c828ea2db1362af7209b2adb1bb8532cea2fb36f",
-                "sha256:31a046ab040a84a0fc38bc93694876398e62bc9f35eca8ccbf6418b7297f4c00",
-                "sha256:3b1a411909c84b2ae9b8283b58b48541654b918e8513c20a400bb946aa9111ae",
-                "sha256:48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d",
-                "sha256:540c9caa57a22d0d5d3c69047cc9dd0094d49782603eb03069821b41f9e970e9",
-                "sha256:672e418425d957e276c291930a3921b4a6413204f53fe7c37cad7bc57b9a3391",
-                "sha256:6ed3b9b3fdc7193ea7aca6f3c20549b377a56f28769783a8f27191903a54170f",
-                "sha256:9371290aa2cad5ad133e4cdc43892778efd13293406f7340b9ffe99d5ec7c1d9",
-                "sha256:ace6ac1d0f87d4072f05b5468a084a45b4eda970e4d26704f201e06d47ab2990",
-                "sha256:b428f883d2b3fe1d052c630642cc6afddd07d5cd7873da948644508be3b9d4a7",
-                "sha256:d5bf0e6ec8ba346a2cf35cb55bf4adfddbc6b6576fcc9e10863daa523e418dbb",
-                "sha256:d7574e283f83c08501607586b3167728c58e8442947e027d2d4c7dcd6d82f453",
-                "sha256:dc889c84241a857c263a2b1cd1121507db7d5b5f5e87e77147097230f374d10b",
-                "sha256:f4748697b349f373002656bf32fede706a0e713d67bfdcf04edf39b1f61d46eb"
+                "sha256:0a9a45157e532da06fe56adcfef8a74629566b607fa2c1ac0122d1ff995c748a",
+                "sha256:2c35cae79ceb20d47facfad51f952df16c2ae9f45db6cb38405a3da1cf8fc0a7",
+                "sha256:4b9365ade157794cef9685791032521233729cb00ce76b0ddc78749abea463d2",
+                "sha256:53ea810ae3f83f9c9b452582261ea859828a9ed666f2e1ca840300b69322c474",
+                "sha256:634aef60b4ff0f650d3e59d4374626ca6153fcaff96ec075b215b568e6ee3cb0",
+                "sha256:7e396ce53cacd5596ff6d191b47ab0ea18f8e0ec04e15d69728d530e86d4c217",
+                "sha256:7eadc91af8270455e0d73565b8964da1642fe226665dd5c9560067cd64d56749",
+                "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6",
+                "sha256:85baab8d74ec601e86134afe2bcccd87820f79d2f8d5798c889507d1088287bf",
+                "sha256:87c556fb85d709dacd4b4cb6167eecc5bbb4f0a9864b69136a0d4640fdc76a36",
+                "sha256:a6bd44efee4dc8c3324c13785a9dc3519b3ee3a92cada42d2b57762b7053b49b",
+                "sha256:c6d27bd20c3ba60d5b02f20bd28e20091d6286a699174dfad515636cb09b5a72",
+                "sha256:e2bb577d10d09a2d8822a042a23b8d62bc3b269667c9eb8e60a6edfa000211b1",
+                "sha256:f97a605d7c8bc2c6d1172c2f0d5a65b24142e11a58de689046e62c2d632ca8c1"
             ],
             "index": "pypi",
-            "version": "==0.740"
+            "version": "==0.761"
         },
         "mypy-extensions": {
             "hashes": [
@@ -263,24 +255,24 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:2c8e420cd4ed4cec4e7999ee47409e876af575d4c35a45840d59e8b5f3155ab8",
-                "sha256:b32c8ccaac7b1a20c0ce00ce317642e6cf231cf038f9875e0280e28af5bf7ac9"
+                "sha256:139d2625547dbfa5fb0b81daebb39601c478c21956dc57e2e07b74450a8c506b",
+                "sha256:61aa52a0f18b71c5cc58232d2cf8f8d09cd67fcad60b742a60124cb8d6951488"
             ],
-            "version": "==5.4.3"
+            "version": "==5.4.4"
         },
         "pluggy": {
             "hashes": [
-                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
-                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "py": {
             "hashes": [
-                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
-                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
             ],
-            "version": "==1.8.0"
+            "version": "==1.8.1"
         },
         "pycodestyle": {
             "hashes": [
@@ -298,25 +290,25 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
-                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+                "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b",
+                "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"
             ],
-            "version": "==2.4.2"
+            "version": "==2.5.2"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1",
-                "sha256:61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.4"
+            "version": "==2.4.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6",
-                "sha256:58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"
+                "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa",
+                "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"
             ],
             "index": "pypi",
-            "version": "==5.2.2"
+            "version": "==5.3.2"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -343,11 +335,11 @@
         },
         "pytest-xdist": {
             "hashes": [
-                "sha256:5d1b1d4461518a6023d56dab62fb63670d6f7537f23e2708459a557329accf48",
-                "sha256:a8569b027db70112b290911ce2ed732121876632fb3f40b1d39cd2f72f58b147"
+                "sha256:0f46020d3d9619e6d17a65b5b989c1ebbb58fc7b1da8fb126d70f4bac4dfeed1",
+                "sha256:7dc0d027d258cd0defc618fb97055fbd1002735ca7a6d17037018cf870e24011"
             ],
             "index": "pypi",
-            "version": "==1.30.0"
+            "version": "==1.31.0"
         },
         "pytz": {
             "hashes": [
@@ -395,11 +387,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:31088dfb95359384b1005619827eaee3056243798c62724fd3fa4b84ee4d71bd",
-                "sha256:52286a0b9d7caa31efee301ec4300dbdab23c3b05da1c9024b4e84896fb73d79"
+                "sha256:298537cb3234578b2d954ff18c5608468229e116a9757af3b831c2b2b4819159",
+                "sha256:e6e766b74f85f37a5f3e0773a1e1be8db3fcb799deb58ca6d18b70b0b44542a5"
             ],
             "index": "pypi",
-            "version": "==2.2.1"
+            "version": "==2.3.1"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -493,17 +485,17 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
-                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
+                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
+                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
             ],
-            "version": "==1.25.6"
+            "version": "==1.25.7"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
-                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
             ],
-            "version": "==0.1.7"
+            "version": "==0.1.8"
         },
         "wheel": {
             "hashes": [
@@ -515,11 +507,11 @@
         },
         "yapf": {
             "hashes": [
-                "sha256:02ace10a00fa2e36c7ebd1df2ead91dbfbd7989686dc4ccbdc549e95d19f5780",
-                "sha256:6f94b6a176a7c114cfa6bad86d40f259bbe0f10cf2fa7f2f4b3596fc5802a41b"
+                "sha256:712e23c468506bf12cadd10169f852572ecc61b266258422d45aaf4ad7ef43de",
+                "sha256:cad8a272c6001b3401de3278238fdc54997b6c2e56baa751788915f879a52fca"
             ],
             "index": "pypi",
-            "version": "==0.28.0"
+            "version": "==0.29.0"
         }
     }
 }

--- a/docs/source/FRAMEWORK.md
+++ b/docs/source/FRAMEWORK.md
@@ -165,6 +165,27 @@ await t.commit()
 
 The *commit* method will inspect all models stored on the transaction's internal cache and verify which models should be modified. Its is not up to the BLL anymore to figure out in which order the operations need to be persisted on the remote server, and which models are unchanged. The transaction will take care of drawing the graph of dependencies between models and trigger all requests to the remote REST API accordingly.
 
+If anything goes wrong when processing a model, then it is possible to revisit all tasks performed by the commit:
+
+```python
+from restio import DAOTask
+
+...
+
+tasks = await t.commit()
+
+dao_task: DAOTask
+for dao_task in tasks:
+    try:
+        # obtains the value returned by the DAO function, if any
+        result = await dao_task
+    except Exception:
+        # if something went wrong during the commit, then it is time
+        # to treat it - below, we just print the stack trace to the
+        # terminal
+        dao_task.task.print_stack()
+```
+
 # More information
 
 The page [Strategies](STRATEGIES.md) contains important information about the internals of *restio*. Please read this page if you consider using this framework in production.

--- a/docs/source/STRATEGIES.md
+++ b/docs/source/STRATEGIES.md
@@ -90,12 +90,13 @@ The logic for deciding the order in which models are persisted is the following:
   - All trees in a graph are processed in parallel in the `asyncio` event loop.
   - Each group of nodes are scheduled in parallel in the `asyncio` event loop.
   - As soon as a node is processed, the next node(s) is (are) scheduled to be persisted if the tree structure allows (that means, if all children of a particular node have been processed, that node can be processed). Otherwise, the processor awaits until a new node is processed, and the inspection for a new node restarts.
-  - If an error occurs, the processing will bexception_queuee conditioned to the `PersistencyStrategy` defined for the transaction. This should be set per transaction scope and the choice might vary according to the use case:
+  - If an error occurs, the processing will be conditioned to the `PersistencyStrategy` defined for the transaction. This should be set per transaction scope and the choice might vary according to the use case:
     - `INTERRUPT_ON_ERROR` will cause the commit to interrupt the scheduling of new nodes and will wait until current processes finalize.
     - `CONTINUE_ON_ERROR` will cause the commit to ignore the error messages and continue processing all available nodes.
   - Models that have been persisted on the remote will be also persisted on the local cache, while models not processed or processed with error are not persisted on cache. This behavior does not depend on the `PersistencyStrategy`. Models that have been deleted will be discarded from cache, and models that changed primary keys will be re-registered after the commit is done.
 
-6. If any error occured, a `TransactionError` will be thrown containing a queue with all errors caught, and a queue with all models that have been processed correctly.
+6. All processed actions performed by the DAOs are returned by the `commit` in the form of a list of `DAOTask`s. Each `DAOTask` can then be awaited after the commit. Tasks that raised an `Exception` during the commit will then
+raise it once more upon awaiting.
 
 ### Rollback
 

--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -1,5 +1,5 @@
 from .cache import ModelCache, QueryCache
-from .dao import BaseDAO
+from .dao import BaseDAO, DAOTask
 from .event import EventListener
 from .graph import DependencyGraph, Node, Tree
 from .model import BaseModel, PrimaryKey, mdataclass
@@ -17,6 +17,7 @@ __all__ = [
     'Transaction',
     'ModelState',
     'PrimaryKey',
+    'DAOTask'
     'query',
     'mdataclass',
 ]

--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -8,7 +8,7 @@ from .state import ModelState, ModelStateMachine, Transition
 from .transaction import Transaction, TransactionState
 
 __name__ = "restio"
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     'BaseModel',

--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -5,8 +5,7 @@ from .graph import DependencyGraph, Node, Tree
 from .model import BaseModel, PrimaryKey, mdataclass
 from .query import BaseQuery, query
 from .state import ModelState, ModelStateMachine, Transition
-from .transaction import (Transaction, TransactionError,
-                          TransactionOperationError, TransactionState)
+from .transaction import Transaction, TransactionState
 
 __name__ = "restio"
 __version__ = "0.1.1"
@@ -20,5 +19,4 @@ __all__ = [
     'PrimaryKey',
     'query',
     'mdataclass',
-    'TransactionError'
 ]

--- a/restio/cache.py
+++ b/restio/cache.py
@@ -2,7 +2,7 @@ from collections.abc import Hashable
 from typing import Dict, List, Optional, Set, Tuple, Type, overload
 from uuid import UUID
 
-from .model import BaseModel, ValueKey
+from .model import BaseModel, ValueKey, _check_model_type
 from .query import BaseQuery
 
 IdCacheKey = Tuple[str, str]
@@ -27,10 +27,6 @@ class ModelCache:
         """
         self._id_cache = {}
         self._key_cache = {}
-
-    def _check_object_type(self, obj: Optional[BaseModel]):
-        assert obj is not None
-        assert isinstance(obj, BaseModel)
 
     def register(self, obj: BaseModel, force: bool = False) -> bool:
         """Registers a model into the internal cache.
@@ -74,7 +70,7 @@ class ModelCache:
         self._remove_from_cache(cached_model_id, cached_model_key)
 
     def _get_type_key_hash(self, obj: BaseModel):
-        self._check_object_type(obj)
+        _check_model_type(obj)
 
         obj_type = obj.__class__
         obj_pk = obj.get_keys()
@@ -205,8 +201,8 @@ class QueryCache:
                       if it is already registered in cache. Defaults to False
         :return: True if the results have been registered. False otherwise.
         """
-        assert obj is not None
-        assert isinstance(obj, Hashable)
+        if not isinstance(obj, BaseQuery) or not isinstance(obj, Hashable):
+            raise TypeError("The provided `obj` should be a hashable instance of BaseQuery")
 
         h = str(obj.__hash__())
         cached = None

--- a/restio/dao.py
+++ b/restio/dao.py
@@ -1,15 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+import time
 from functools import wraps
-from typing import Optional, Tuple, Type
+from typing import Any, Callable, Optional, Tuple, Type
+
+from restio.graph import Node
 
 from .model import BaseModel, ValueKey
+
+NOT_IMPLEMENTED_DAO_FUNC_ATTR = "dao_method_not_implemented"
 
 
 def not_implemented_method(function):
     @wraps(function)
     def wrapper(self, obj):
-        raise RuntimeError(f'Method {function.__name__} not implemented.')
+        raise NotImplementedError(f'Method {function.__name__} not implemented.')
 
+    setattr(wrapper, NOT_IMPLEMENTED_DAO_FUNC_ATTR, True)
     return wrapper
+
+
+def check_dao_implemented_method(function):
+    if (
+        hasattr(function, NOT_IMPLEMENTED_DAO_FUNC_ATTR) and
+        getattr(function, NOT_IMPLEMENTED_DAO_FUNC_ATTR)
+    ):
+        raise NotImplementedError(
+            f"Function `{function.__name__}` of DAO {function.__self__.__class__.__name__} not implemented.")
 
 
 class BaseDAO:
@@ -85,3 +103,95 @@ class BaseDAO:
         :param obj: The model to be updated.
         """
         pass
+
+
+DAOTaskCallable = Callable[[BaseModel], Any]
+
+
+class DAOTask:
+    """
+    Wrapper object that, when awaited, contains a asyncio.Task running a DAO function
+    during a Transaction commit.
+
+    When a DAOTask instance is awaited for the first time, it triggers `run_task()`
+    and returns the result from the undelying task wrapping `func`. Awaiting the same
+    instance multiple times will not retrigger the task, but instead will return the
+    value from the first call. Alternatively, it is also possible to retrieve the underlying
+    task directly through the attribute `task`.
+
+    Running a DAOTask will also record the `start_time` and `end_time` of the first execution.
+    """
+    _task: Optional[asyncio.Task]
+    node: Node
+    func: DAOTaskCallable
+    start_time: float
+    end_time: float
+
+    def __init__(self, node: Node, func: DAOTaskCallable):
+        self.node = node
+        self.func = func  # type: ignore
+        self.start_time = 0.0
+        self.end_time = 0.0
+        self._task = None
+
+    def run_task(self) -> asyncio.Task:
+        """
+        Creates and returns a asyncio.Task that runs `func` when called for the first time.
+        When called multiple times, returns the existing asyncio.Task created during the
+        first execution.
+
+        :return: The asyncio.Task instance.
+        """
+        if self._task:
+            return self._task
+
+        self.start_time = time.time()
+
+        task: asyncio.Task = asyncio.create_task(self.func(self.node.node_object))  # type: ignore
+        task.add_done_callback(self._task_finished)
+
+        self._task = task
+        return task
+
+    def __await__(self):
+        return self.run_task().__await__()
+
+    @property
+    def task(self) -> asyncio.Task:
+        """
+        Contains the underlying asyncio.Task.
+
+        :raises RuntimeError: When a Task has not yet been triggered.
+        :return: The asyncio.Task instance.
+        """
+        if not self._task:
+            raise RuntimeError("DAOTask not started.")
+        return self._task
+
+    def _task_finished(self, future):
+        self.end_time = time.time()
+        self.task.remove_done_callback(self._task_finished)
+
+    @property
+    def duration(self) -> float:
+        """
+        Returns the duration of the execution (in seconds).
+
+        :raises RuntimeError: When the execution has not been finished.
+        :return: The duration (in seconds).
+        """
+        if not self.start_time or not self.end_time:
+            raise RuntimeError("Task not finished.")
+        return self.end_time - self.start_time
+
+    @property
+    def model(self) -> BaseModel:
+        """
+        Returns the BaseModel contained by the `node`.
+
+        :return: The BaseModel instance.
+        """
+        return self.node.node_object
+
+    def __lt__(self, value: DAOTask):
+        return self.end_time < value.end_time

--- a/restio/model.py
+++ b/restio/model.py
@@ -13,6 +13,11 @@ from .state import ModelState
 T = TypeVar('T', int, str, None)
 
 
+def _check_model_type(obj: Optional[BaseModel]):
+    if not isinstance(obj, BaseModel):
+        raise TypeError("The provided object is not of type BaseModel.")
+
+
 class PrimaryKey(Generic[T]):
     """
     Represents a primary key in a remote model, in a similar fashion as if

--- a/tests/unit/test_dao.py
+++ b/tests/unit/test_dao.py
@@ -1,0 +1,161 @@
+import asyncio
+
+import pytest
+
+from restio.dao import BaseDAO, DAOTask, check_dao_implemented_method
+from restio.graph import Node
+from restio.model import BaseModel
+
+
+class DAOEmptyMock(BaseDAO):
+    pass
+
+
+class ModelMock(BaseModel):
+    pass
+
+
+class DAOMissingAddRemoveUpdateMock(BaseDAO):
+    async def get(self, keys) -> None:
+        pass
+
+
+class DAOMock(BaseDAO):
+    async def get(self, keys) -> None:
+        pass
+
+    async def add(self, obj: BaseModel) -> BaseModel:
+        await asyncio.sleep(0.1)
+        return obj
+
+    async def update(self, obj: BaseModel) -> BaseModel:
+        await asyncio.sleep(0.2)
+        return obj
+
+    async def remove(self, obj: BaseModel) -> BaseModel:
+        await asyncio.sleep(0.3)
+        return obj
+
+    async def error(self, obj: BaseModel) -> BaseModel:
+        raise RuntimeError("error")
+
+
+class TestDAO:
+
+    @pytest.fixture
+    def empty_dao(self):
+        return DAOEmptyMock(ModelMock)
+
+    @pytest.fixture
+    def missing_funcs_dao(self):
+        return DAOMissingAddRemoveUpdateMock(ModelMock)
+
+    def test_check_empty_dao(self, empty_dao):
+        funcs = [empty_dao.get, empty_dao.add, empty_dao.remove, empty_dao.update]
+
+        for func in funcs:
+            with pytest.raises(NotImplementedError, match="not implemented"):
+                func("any")
+
+    def test_check_empty_methods(self, empty_dao):
+        funcs = [empty_dao.get, empty_dao.add, empty_dao.remove, empty_dao.update]
+
+        for func in funcs:
+            with pytest.raises(NotImplementedError, match="not implemented"):
+                check_dao_implemented_method(func)
+
+    def test_check_missing_methods(self, missing_funcs_dao):
+        funcs = [missing_funcs_dao.add, missing_funcs_dao.remove, missing_funcs_dao.update]
+
+        for func in funcs:
+            with pytest.raises(NotImplementedError, match="DAOMissingAddRemoveUpdateMock not implemented"):
+                check_dao_implemented_method(func)
+
+        check_dao_implemented_method(missing_funcs_dao.get)
+
+
+class TestDAOTask:
+    @pytest.fixture
+    def model(self) -> ModelMock:
+        return ModelMock()
+
+    @pytest.fixture
+    def node(self, model) -> Node:
+        return Node(model)
+
+    @pytest.fixture
+    def dao(self, model) -> DAOMock:
+        return DAOMock(type(model))
+
+    @pytest.fixture
+    def task_add(self, model: BaseModel, node: Node, dao: DAOMock):
+        return DAOTask(node, dao.add)
+
+    @pytest.fixture
+    def task_update(self, model: BaseModel, node: Node, dao: DAOMock):
+        return DAOTask(node, dao.update)
+
+    @pytest.fixture
+    def task_remove(self, model: BaseModel, node: Node, dao: DAOMock):
+        return DAOTask(node, dao.remove)
+
+    @pytest.fixture
+    def task_error(self, model: BaseModel, node: Node, dao: DAOMock):
+        return DAOTask(node, dao.error)
+
+    def test_instantiate(self, task_add: DAOTask, node: Node, dao: DAOMock):
+        assert task_add.node == node
+        assert task_add.func == dao.add  # type: ignore
+        assert task_add.start_time == 0.0
+        assert task_add.end_time == 0.0
+        assert task_add._task is None
+
+    @pytest.mark.asyncio
+    async def test_await(self, task_add: DAOTask, model: BaseModel):
+        assert await task_add.run_task() == model
+        assert await task_add.task == model
+        assert await task_add == model
+
+    @pytest.mark.asyncio
+    async def test_await_error(self, task_error: DAOTask):
+        with pytest.raises(RuntimeError, match="error"):
+            assert await task_error.run_task()
+
+        with pytest.raises(RuntimeError, match="error"):
+            assert await task_error.task
+
+        with pytest.raises(RuntimeError, match="error"):
+            assert await task_error
+
+    @pytest.mark.asyncio
+    async def test_run_task(self, task_add: DAOTask):
+        task = task_add.run_task()
+        await task
+
+        assert task is not None
+        assert task_add._task == task
+        assert task_add.task == task
+        assert task_add.duration > 0.0
+
+    @pytest.mark.asyncio
+    async def test_duration(self, task_add: DAOTask):
+        await task_add
+        assert task_add.start_time > 0.0
+        assert task_add.end_time > 0.0
+        assert task_add.duration > 0.0
+
+    @pytest.mark.asyncio
+    async def test_duration_not_started(self, task_add: DAOTask):
+        with pytest.raises(RuntimeError, match="not finished"):
+            task_add.duration
+
+    def test_model(self, task_add: DAOTask, model: ModelMock):
+        assert task_add.model == model
+
+    @pytest.mark.asyncio
+    async def test_order(self, task_add: DAOTask, task_update: DAOTask, task_remove: DAOTask):
+        tasks = [task_remove, task_update, task_add]
+        await asyncio.wait(tasks)
+
+        sorted_results = sorted(tasks)
+        assert sorted_results == [task_add, task_update, task_remove]


### PR DESCRIPTION
The changes introduced in this PR modify the interface of `Transaction.commit` by adding a new class `DAOTask` that wraps all internal DAO calls made during the `commit`. Calls are now returned by `commit` as a list of `DAOTask` objects, in the order of processing. All `DAOTask` objects are awaitable and can return the value generated by the DAO function (if any) or re-raise their exceptions.

As a result, `commit` no longer raises any Exception, and it is up to the utilizer to scan through the list of `DAOTask` to look for issues (when applicable). Therefore, the following coherent actions also apply:
- The exceptions `TransactionError` and `TransactionOperationError` have been removed from the framework (`restio.transaction`).
- Same for `NodeProcessException` and `TreeProcessException` (`restio.graph`).

For the above changes, the algorithm that schedules the DAO functions (`add`, `update` and `remove`, now wrapped into `DAOTask` in runtime) in the correct order has been greatly improved to be easier to read and more maintainable.

Finally as a side improvement, failing to implement DAO methods no longer triggers errors during `commit`, but whenever the application tries to mark models for ADD, UPDATE or DELETE in a Transaction. The following conditions are now prohibited during `Transaction.add`, `Transaction.remove` and `Transaction._update` (this means, whenever a model registered in a transaction has one of its fields changed):
- The model type does not have an associated DAO.
- The associated DAO doesn't implement the correspondent operation.

This change gives developers earlier feedback and prevents the `commit` to be triggered with invalid models, therefore avoiding batches of calls to the remote rest API before a NotImplementedError is raised.