### PR TITLE
Fixing missing iterables for parsing child models

### DIFF
--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -8,7 +8,7 @@ from .state import ModelState, ModelStateMachine, Transition
 from .transaction import Transaction, TransactionState
 
 __name__ = "restio"
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     'BaseModel',

--- a/restio/model.py
+++ b/restio/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import types
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import wraps
 from typing import (Any, Dict, Generic, List, Optional, Set, Tuple, Type,
@@ -261,7 +262,12 @@ class BaseModel(Generic[T], metaclass=BaseModelMeta):
                     else:
                         children.append(child)
 
-            if isinstance(value, list) or isinstance(value, set):
+            # iterables are only supported if the values
+            # are not iterables - there is no recursiveness
+            if isinstance(value, Iterable):
+                if isinstance(value, dict):
+                    value = value.values()
+
                 for item in value:
                     check(item)
             else:

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -157,12 +157,28 @@ class TestModel:
         assert a.b == old_value_b
         assert 'b' not in a._persistent_values
 
-    def test_get_children(self):
+    @pytest.mark.parametrize("iterable", [list, set, frozenset, tuple])
+    def test_get_children_with_iterable(self, iterable):
         a = ModelA()
         b = ModelB()
         c = ModelC()
 
-        c.ref, b.ref = [b], a
+        c.ref, b.ref = iterable([b]), a
+
+        all_children = c.get_children(True)
+        assert a in all_children
+        assert b in all_children
+
+        one_child = c.get_children(False)
+        assert b in one_child
+        assert a not in one_child
+
+    def test_get_children_with_dict(self):
+        a = ModelA()
+        b = ModelB()
+        c = ModelC()
+
+        c.ref, b.ref = {"v": b}, a
 
         all_children = c.get_children(True)
         assert a in all_children


### PR DESCRIPTION
Before this change, It wasn't possible to properly generate dependency graphs for models in which children were stored in structures other than `list` or `set`.
The change now allows for using any iterable that passes the check `isinstance(value, collections.abc.Iterable)`.