### PR TITLE
Add support for configurable mutability

### DIFF
--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -8,7 +8,7 @@ from .state import ModelState, ModelStateMachine, Transition
 from .transaction import Transaction, TransactionState
 
 __name__ = "restio"
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 __all__ = [
     'BaseModel',


### PR DESCRIPTION
Resolves the issue #16, when declared fields with non-default
values in a model were not selected as mutable. Now, it is possible
to explicitly define fields as mutable/immutable using the static
attributes __mutable__ and __immutable__ for those cases. The
definitions will be carried across to child classes automatically.