### PR TITLE
Fix check of deleted models in dependency graph

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.0.0b2
+-------
+
+- Fixed bug that failed to properly check trees of models with deleted state.
 
 1.0.0b1
 -------

--- a/restio/__init__.py
+++ b/restio/__init__.py
@@ -1,4 +1,4 @@
 __name__ = "restio"
-__version__ = "1.0.0b1"
+__version__ = "1.0.0b2"
 __author__ = "Eduardo Machado Starling"
 __email__ = "edmstar@gmail.com"

--- a/restio/transaction.py
+++ b/restio/transaction.py
@@ -585,7 +585,7 @@ class Transaction:
             models_to_remove
         )
 
-        self._check_deleted_models(models_to_remove)
+        self._check_deleted_models(cached_values)
 
         # add, update and remove get one graph each, as
         # each level needs to be completely finished in
@@ -615,8 +615,8 @@ class Transaction:
             self.update_cache()
         return results
 
-    def _check_deleted_models(self, models: Optional[Set[BaseModel]] = None):
-        models = set(self._model_cache._id_cache.values()) if not models else models
+    @staticmethod
+    def _check_deleted_models(models: Set[BaseModel]):
         nodes = DependencyGraph._get_connected_nodes(models)
         for node in (n for n in nodes if n.node_object._state == ModelState.DELETED):
             for parent_node in node.get_parents(recursive=True):


### PR DESCRIPTION
This bug caused models to not be properly checked for deletion when commiting a transaction. It was possible to delete a model that was a dependency for another model, which is incorrect.

Now the check is properly done and only trees with all models deleted can be safely commited.